### PR TITLE
Error in content-length for multibyte characters

### DIFF
--- a/client.js
+++ b/client.js
@@ -116,7 +116,7 @@ function send(payload, deviceId) {
         method: 'POST',
         headers: {
             'Authorization': token,
-            'Content-Length': payload.length,
+            'Content-Length': Buffer.byteLength(payload),
             'Content-Type': 'application/atom+xml;type=entry;charset=utf-8'
         }
     }


### PR DESCRIPTION
payload.length counts characters, while Buffer.byteLength counts actual bytes
https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding
